### PR TITLE
Update README.md (Add "s" to ".h")

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The code are supposed to be dowloaded to our source tree to be used. 
 
 ```
-wget https://raw.githubusercontent.com/cee-studio/cee-utils/master/scripts/get-cee-utils.h 
-./get-cee-utils.h
+wget https://raw.githubusercontent.com/cee-studio/cee-utils/master/scripts/get-cee-utils.sh 
+./get-cee-utils.sh
 ```
 
 


### PR DESCRIPTION
The README.md was without "s", making an H file, not a shell file.